### PR TITLE
Correction des calculs astronomiques

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'faker'
 gem "astronomy"
 gem "geocoder"
 gem "httparty"
+gem "tzinfo"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
+  tzinfo
   tzinfo-data
   validates_timeliness (~> 7.0.0.beta1)
   web-console

--- a/app/models/observation_planning.rb
+++ b/app/models/observation_planning.rb
@@ -1,6 +1,5 @@
 require "json"
 require "httparty"
-require "time"
 require "tzinfo"
 
 class ObservationPlanning < ApplicationRecord
@@ -117,13 +116,14 @@ class ObservationPlanning < ApplicationRecord
     json = JSON.parse(response.body)
 
     unformated_rise = Time.parse(json['results']['nautical_twilight_begin'])
-    sunrise = (unformated_rise + utc_offset.hours).strftime('%H:%M')
+    sunrise = (unformated_rise + (utc_offset.hours + 1.hours)).strftime('%H:%M')
     unformated_set = Time.parse(json['results']['nautical_twilight_end'])
-    sunset = (unformated_set + utc_offset.hours).strftime('%H:%M')
+    sunset = (unformated_set + (utc_offset.hours + 1.hours)).strftime('%H:%M')
 
     self.sunrise = sunrise
     self.sunset = sunset
   end
+
 
   # call the api to get the moon phase for the date of the observation and rise/set time for user location
   def moon(date)

--- a/app/models/observation_planning.rb
+++ b/app/models/observation_planning.rb
@@ -51,12 +51,13 @@ class ObservationPlanning < ApplicationRecord
       ra, dec = parse_ra_and_dec(object) # Extract right ascension and declination from object data
       altitude, azimuth = calculate_altitude_and_azimuth(ra, dec, lst, observer_latitude, observer_longitude) # Calculate altitude and azimuth of object at start of observation
 
-      if altitude > 10 # If the object is above the horizon, add it to the selected_objects array with its altitude and azimuth
+      if altitude > 20 # If the object is above the horizon, add it to the selected_objects array with its altitude and azimuth
         selected_objects << object.merge(altitude: altitude, azimuth: azimuth)
       end
     end
+    sorted_objects = selected_objects.sort_by { |obj| -obj[:altitude] }
     # Retourne un array des objets visible trié par ordre décroissant de leur altitude
-    return selected_objects.sort_by! { |obj| -obj[:altitude] } # Return the array of visible objects
+    return sorted_objects # Return the array of visible objects
   end
 
   # Calculate the local sidereal time at a given location and time
@@ -75,7 +76,7 @@ class ObservationPlanning < ApplicationRecord
   # Convert right ascension and declination from hours/degrees, minutes, and seconds to decimal degrees
   def parse_ra_and_dec(object)
     ra_hours, ra_minutes, ra_seconds = object['ra'].split(':').map(&:to_f) # Split right ascension into hours, minutes, and seconds
-    ra = hms_to_decimal(ra_hours, ra_minutes, ra_seconds) # Convert right ascension to decimal hours
+    ra = (hms_to_decimal(ra_hours, ra_minutes, ra_seconds) * 360) / 24 # Convert right ascension to decimal degrees
     dec_degrees, dec_minutes, dec_seconds = object['dec'].split(':').map(&:to_f) # Split declination into degrees, minutes, and seconds
     dec = dec_degrees + (dec_minutes / 60.0) + (dec_seconds / 3600.0) # Convert declination to decimal degrees
 
@@ -84,8 +85,13 @@ class ObservationPlanning < ApplicationRecord
 
   # Calculate object's altitude and azimuth at a given time and location
   def calculate_altitude_and_azimuth(ra, dec, lst, observer_latitude, _observer_longitude)
-    object_altitude = Math.asin((Math.sin(dec * Math::PI / 180) * Math.sin(observer_latitude * Math::PI / 180)) + (Math.cos(dec * Math::PI / 180) * Math.cos(observer_latitude * Math::PI / 180) * Math.cos((lst - ra) * Math::PI / 180)))
-    object_azimuth = Math.atan2(-Math.sin((lst - ra) * Math::PI / 180), (Math.tan(observer_latitude * Math::PI / 180) * Math.cos(dec * Math::PI / 180)) - (Math.sin(dec * Math::PI / 180) * Math.cos((lst - ra) * Math::PI / 180)))
+    ra_rad = ra * Math::PI / 180
+    dec_rad = dec * Math::PI / 180
+    lst_rad = lst * Math::PI / 180
+    observer_latitude_rad = observer_latitude * Math::PI / 180
+
+    object_altitude = Math.asin((Math.sin(dec_rad) * Math.sin(observer_latitude_rad)) + (Math.cos(dec_rad) * Math.cos(observer_latitude_rad) * Math.cos(lst_rad - ra_rad)))
+    object_azimuth = Math.atan2(-Math.sin(lst_rad - ra_rad), (Math.tan(observer_latitude_rad) * Math.cos(dec_rad)) - (Math.sin(dec_rad) * Math.cos(lst_rad - ra_rad)))
 
     azimuth = ((object_azimuth * 180 / Math::PI) + 360) % 360 # Convert azimuth from radians to degrees
     altitude = object_altitude * 180 / Math::PI # Convert altitude from radians to degrees

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,13 +1,16 @@
+require 'dotenv'
+Dotenv.load
+
 Geocoder.configure(
   # Geocoding options
-  # timeout: 3,                 # geocoding service timeout (secs)
-  # lookup: :nominatim,         # name of geocoding service (symbol)
+  timeout: 5,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code
-  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  # api_key: nil,               # API key for geocoding service
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
 
   # Exceptions that should not be rescued by default


### PR DESCRIPTION
BUNDLE INSTALL NECESSAIRE- DEMANDER l'API KEY Google maps à JULIEN -> Sinon ça fonctionnera pas sur vos localhost

Les celestial bodies affiché dans le planning d'obsevration sont maintenant 100% corrects.
Il y a avait un problème de conversion des heures en degrés et des degrés en radians.
J'ai complété la méthode utc offset, pour que les calculs tiennent compte du fuseau horaire de l'utilisateur en fonction de user.latitude et user.longitude, ainsi que des passages heure d'été/hiver. Donc, on peut maintenant calculer un planning pour n'importe où et n'importe quand sur la planète.

J'ai modifié la config de la gem Geocoder et ajouté une API google maps avec ma clé personnelle. 

J'ai corrigé la méthode Sun qui donnait l'heure de lever et coucher avec une heure de décalage.


