### PR TITLE
Black screen fix

### DIFF
--- a/app/controllers/observation_plannings_controller.rb
+++ b/app/controllers/observation_plannings_controller.rb
@@ -5,6 +5,6 @@ class ObservationPlanningsController < ApplicationController
 
   def show
     @observation_planning = ObservationPlanning.find(params[:id])
-    @visible_objects = @observation_planning.visible_objects
+    @visible_objects = JSON.parse(@observation_planning.visible_objects)
   end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -27,7 +27,8 @@ class Booking < ApplicationRecord
     planning.name = "Plan d'observation du #{date.strftime("%d.%m.%y")}"
     # add 8 celestial bodies to the observation planning, wich are the 8 first celestial bodies corresponding
     # to the ones returned by the visible_objects method
-    planning.celestial_bodies = planning.visible_objects.first(8).map { |object| CelestialBody.find_by!(name: object["messier"]) }
+    planning.select_objects # call the select_objects method from the observation planning model
+    planning.celestial_bodies = JSON.parse(planning.visible_objects).first(8).map { |object| CelestialBody.find_by!(name: object["messier"]) }
     # call the moon method from the observation planning model to get the moon_phase image url
     planning.moon(date.strftime("%Y-%m-%d"))
     planning.save

--- a/app/models/observation_planning.rb
+++ b/app/models/observation_planning.rb
@@ -65,7 +65,7 @@ class ObservationPlanning < ApplicationRecord
     # Trie selected_objects par ordre décroissant de leur altitude
     sorted_objects = selected_objects.sort_by { |obj| -obj[:altitude] }
     # Sauvegarde les objets visibles dans la base de données
-    self.visible_objects = sorted_objects
+    self.visible_objects = sorted_objects.to_json
 
     return sorted_objects # Return the array of visible objects
   end

--- a/app/views/observation_plannings/show.html.erb
+++ b/app/views/observation_plannings/show.html.erb
@@ -1,6 +1,7 @@
 <div class= "container-fluid" data-controller="observation pointage">
   <div class="titre m-3" >
     <h2 class="text-shadow" style="font-size: 2rem"> <%= "#{@observation_planning.name.upcase} POUR #{@observation_planning.user.first_name.upcase}" %></h2>
+    <h3 class="text-shadow" style="font-size: 1.5rem"><%= "À #{@observation_planning.user.city.upcase}"%></h3>
     <h3 class="text-shadow" style="font-size: 1.5rem"><%= "DE #{@observation_planning.start_time.strftime("%H:%M")} À #{@observation_planning.end_time.strftime("%H:%M")}" %></h3>
   </div>
   <div class="sunmoon col-12 d-flex flex-row justify-content-center  mb-3">
@@ -40,15 +41,15 @@
           </div>
           <div class="d-flex flex-row  align-items-center">
             <%= image_tag "azimuth.png",  width:'20', height:'20'%>
-            <p><strong>Azimuth: </strong><%= @visible_objects.find {|f| f['messier'] == celestial_body.name}[:azimuth].round %>°</p>
+            <p><strong>Azimuth: </strong><%= @visible_objects.find {|f| f['messier'] == celestial_body.name}['azimuth'].round %>°</p>
           </div>
           <div class="d-flex flex-row  align-items-center">
             <i class="fa-solid fa-arrow-up px-1"></i>
-            <p><strong>Altitude:</strong> <%= @visible_objects.find {|f| f['messier'] == celestial_body.name}[:altitude].round%>°</p>
+            <p><strong>Altitude:</strong> <%= @visible_objects.find {|f| f['messier'] == celestial_body.name}['altitude'].round%>°</p>
           </div>
           <div class="d-flex flex-row  align-items-center">
             <i class="fa-regular fa-compass px-1"></i>
-            <p><strong>Orientation:</strong> <%= CelestialBody.orientation(@visible_objects.find {|f| f['messier'] == celestial_body.name}[:azimuth]) %></p>
+            <p><strong>Orientation:</strong> <%= CelestialBody.orientation(@visible_objects.find {|f| f['messier'] == celestial_body.name}['azimuth']) %></p>
           </div>
           <div class="description" data-observation-target="description">
             <p><%= celestial_body.description %></p>

--- a/app/views/observation_plannings/show.html.erb
+++ b/app/views/observation_plannings/show.html.erb
@@ -1,7 +1,6 @@
 <div class= "container-fluid" data-controller="observation pointage">
   <div class="titre m-3" >
     <h2 class="text-shadow" style="font-size: 2rem"> <%= "#{@observation_planning.name.upcase} POUR #{@observation_planning.user.first_name.upcase}" %></h2>
-    <h3 class="text-shadow" style="font-size: 1.5rem"><%= "À #{@observation_planning.user.city.upcase}"%></h3>
     <h3 class="text-shadow" style="font-size: 1.5rem"><%= "DE #{@observation_planning.start_time.strftime("%H:%M")} À #{@observation_planning.end_time.strftime("%H:%M")}" %></h3>
   </div>
   <div class="sunmoon col-12 d-flex flex-row justify-content-center  mb-3">

--- a/db/migrate/20230316164506_add_visible_objects_to_observation_plannings.rb
+++ b/db/migrate/20230316164506_add_visible_objects_to_observation_plannings.rb
@@ -1,0 +1,5 @@
+class AddVisibleObjectsToObservationPlannings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :observation_plannings, :visible_objects, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_13_203259) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_164506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_13_203259) do
     t.string "sunrise"
     t.string "sunset"
     t.text "moon_phase"
+    t.text "visible_objects"
     t.index ["user_id"], name: "index_observation_plannings_on_user_id"
   end
 


### PR DESCRIPTION
Problème rencontré lors de la démo:
J'ai créé un planning pour Lausanne avant la démo. J'ai créé un planning pour Lausanne pendant la démo. Jusqu'ici tout fonctionnait. Après la création d'un planning pour Ho Chi Minh Ville, les planning établis pour Lausanne n'était plus affichables -> black screen, error 500.

Le bug a pu être reproduit sur localhost. Sur la console, l'erreur apparaissait dans observation_planning/:id/show, en ligne 44:
@visible_objects.find {|f| f['messier'] == celestial_body.name}[:azimuth].round

Après vérification, voici les raison de l'erreur 500:

- La méthode visible_objects dans ObservationPlanning model créait une liste selected_objects, pour la localité du planning d'observation.

- Cette liste est utilisée dans le model Booking pour aller chercher les celestial_bodies au nom correspondant et pour les lier à l'observation_planning créé.

- Lorsqu'on appelle la view observation_planning/show, la ligne 44 va chercher dans la liste selected_objects l'azimuth des celestial bodies associés au planning d'observation.

- ****La liste selected_objects n'était jamais sauvegardée en base de donnée.** Elle contenait uniquement les objets sélectionnés lors de la dernière création d'un ObservationPlanning.**

- Tout allait bien, lorsque le contenu de la liste selected_object matchait avec les celestials_bodies associé au planning d'observation. C'était le cas uniquement, parce que dans notre travail, nous avons toujours créé des plannings pour des localités suffisamment proches pour que le contenu de la liste selected_objects soit identique, ou presque.

- La création d'un planning pour une localité éloignée de la localité du précédent planning a permis de révéler que le contenu de la liste selected_object(Ho CHi Minh Ville) ne correspondait pas du tout aux celestials-bodys liés au planning d'observation pour Lausanne. 

**- En résumé, le code en ligne 44 de la vue observation_planning/show pour le planning de Lausanne ne trouvait pas les celestial-bodies de Lausanne dans la liste selected_objects de Ho Chi Minh Ville.**

Résolution:
Il faut sauvegarder la liste selected_objects en DB pour chaque planning d'observation.

- Renommé la méthode visible_objects en select_objects
- Renomné la liste selected_objects en visible_objects
- Créé migration AddVisibleObjectsToObservationPlannings => add_column :observation_plannings, :visible_objects, :text
- Ajouté "serialize :visible_objects, JSON" sur le model ObservationPlanning, pour conserver la structure de la liste selected_objects tout en la stockant dans une seule colonne, au format texte.
- Modifié la méthode generate observation planning du model Booking, pour déclencher planning.select_objects et ajusté le code pour chercher les celestials-bodies correspondant au contenu de la liste JSON visible_objects => JSON.parse(planning.visible_objects)
- Modifé l'action show du controller ObservationPlannings pour pour que @visible_objects = JSON.parse(@observation_planning.visible_objects)
- Corrigé les code @visible_objects.find {|f| f['messier'] == celestial_body.name}[:azimuth].round dans observation_planning/show. Azimuth et Altitude ne sont plus des symbols mais des key en format text => @visible_objects.find {|f| f['messier'] == celestial_body.name}["azimuth"].round

J'ai testé en créant des plannings pour Lausanne, Ho Chi Mihn Ville et Melbourne à plusieurs reprises et je n'arrive plus à reproduire le bug.

Les seeds sont passées.